### PR TITLE
Reset input/list on execution

### DIFF
--- a/src/gui/app_builder.rs
+++ b/src/gui/app_builder.rs
@@ -18,7 +18,7 @@ const WINDOW_HEIGHT: i32 = 500;
 pub struct AppBuilder {}
 
 impl AppBuilder {
-    pub fn build() -> (App, HoldBrowser, Receiver<UserEvent>) {
+    pub fn build() -> (App, HoldBrowser, Input, Receiver<UserEvent>) {
         let app = App::default();
         let mut window = Window::default()
             .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
@@ -74,6 +74,6 @@ impl AppBuilder {
         window.end();
         window.show();
 
-        (app, browser, receiver)
+        (app, browser, input, receiver)
     }
 }

--- a/src/gui/app_builder.rs
+++ b/src/gui/app_builder.rs
@@ -57,11 +57,19 @@ impl AppBuilder {
         browser.handle(move |browser, _| {
             // WATCH OUT! This event is global (not for the browser only).
             //
+            // An alternative solution was to reset when tapping key up from the topmost Browser entry,
+            // but this is not feasible with fltk(-rs), because:
+            //
+            // - the event is fired after the selection is changed
+            // - the selection doesn't go above the first entry
+            //
             if event_key_down(Key::Enter) {
                 if let Some(text) = browser.selected_text() {
                     sender_b.send(SelectListEntry(text));
+                    sender_b.send(Reset);
                 } else if let Some(text) = browser.text(1) {
                     sender_b.send(SelectListEntry(text));
+                    sender_b.send(Reset);
                 }
 
                 return true;

--- a/src/gui/user_event.rs
+++ b/src/gui/user_event.rs
@@ -3,4 +3,5 @@ pub enum UserEvent {
     UpdateList(String),
     FocusOnList,
     SelectListEntry(String),
+    Reset,
 }

--- a/src/gui/user_event_handler.rs
+++ b/src/gui/user_event_handler.rs
@@ -1,4 +1,4 @@
-use fltk::{app::set_focus, browser::HoldBrowser, prelude::*};
+use fltk::{app::set_focus, browser::HoldBrowser, input::Input, prelude::*};
 
 use super::user_event::UserEvent::{self, *};
 use crate::search::{searcher::Searcher, searchers_provider::SearchersProvider};
@@ -19,6 +19,7 @@ impl UserEventHandler {
         event: UserEvent,
         searchers_provider: &SearchersProvider,
         browser: &mut HoldBrowser,
+        input: &mut Input,
     ) {
         match event {
             UpdateList(pattern) => {
@@ -44,6 +45,11 @@ impl UserEventHandler {
                 if let Some(searcher) = &self.current_searcher {
                     searcher.execute(entry);
                 }
+            }
+            Reset => {
+                input.set_value("");
+                set_focus(input);
+                browser.clear();
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,13 +15,13 @@ use gui::user_event_handler::UserEventHandler;
 use search::searchers_provider::SearchersProvider;
 
 fn main() {
-    let (app, mut browser, receiver) = AppBuilder::build();
+    let (app, mut browser, mut input, receiver) = AppBuilder::build();
     let mut user_event_handler = UserEventHandler::new();
     let searchers_provider = SearchersProvider::new();
 
     while app.wait() {
         if let Some(event) = receiver.recv() {
-            user_event_handler.handle_event(event, &searchers_provider, &mut browser);
+            user_event_handler.handle_event(event, &searchers_provider, &mut browser, &mut input);
         }
     }
 }


### PR DESCRIPTION
This is useful for searchers that don't exit, ie. EmojiSearcher.

An alternative solution was to reset when tapping key up from the topmost Browser entry, but this is not feasible with fltk(-rs), because:

- the event is fired after the selection is changed
- the selection doesn't go above the first entry