### PR TITLE
Generalize icon images type to SharedImage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ name = "pm-spotlight"
 version = "0.1.0"
 
 [dependencies]
-fltk = {git = "https://github.com/fltk-rs/fltk-rs", rev = "8a28c59903a2b7e6a22d776e53bed758f9dc5e49"}# v1.3.4, with Browser data support
+# Unreleased fltk-rs (v1.3.5) includes Browser data support, and fixes SharedImage::from_image
+fltk = {git = "https://github.com/fltk-rs/fltk-rs", rev = "a0402da3d160f55a5d41b1a8daec3d7a41f58fbc"}
 phf = {version = "0.10.1", features = ["macros"]}

--- a/src/gui/pm_spotlight_app.rs
+++ b/src/gui/pm_spotlight_app.rs
@@ -3,7 +3,7 @@ use fltk::{
     browser::HoldBrowser,
     enums::{CallbackTrigger, Key},
     group::Pack,
-    image::PngImage,
+    image::SharedImage,
     input::Input,
     prelude::*,
     window::Window,
@@ -193,7 +193,7 @@ impl PMSpotlightApp {
      * Helpers
      ***************************************************************************/
 
-    fn set_list_entries(&mut self, entries: Vec<(Option<PngImage>, String, Option<String>)>) {
+    fn set_list_entries(&mut self, entries: Vec<(Option<SharedImage>, String, Option<String>)>) {
         for (icon, entry_text, entry_data) in entries {
             if let Some(entry_data) = entry_data {
                 self.browser.add_with_data(&entry_text, entry_data);

--- a/src/search/emoji_searcher.rs
+++ b/src/search/emoji_searcher.rs
@@ -1,4 +1,4 @@
-use fltk::image::PngImage;
+use fltk::image::{PngImage, SharedImage};
 use phf::phf_map;
 
 use super::searcher::Searcher;
@@ -135,7 +135,7 @@ impl Searcher for EmojiSearcher {
         pattern.starts_with(":")
     }
 
-    fn search(&mut self, pattern: &str) -> Vec<(Option<PngImage>, String, Option<String>)> {
+    fn search(&mut self, pattern: &str) -> Vec<(Option<SharedImage>, String, Option<String>)> {
         let pattern = pattern.chars().skip(1).collect::<String>();
 
         if pattern.len() > 0 {
@@ -143,8 +143,10 @@ impl Searcher for EmojiSearcher {
                 .into_iter()
                 .filter_map(|(emoji, (patterns, image_bytes))| {
                     if patterns.contains(&pattern) {
+                        let shared_image =
+                            SharedImage::from_image(PngImage::from_data(image_bytes).unwrap());
                         Some((
-                            PngImage::from_data(image_bytes).ok(),
+                            shared_image.ok(),
                             patterns.to_string(),
                             Some(emoji.to_string()),
                         ))

--- a/src/search/searcher.rs
+++ b/src/search/searcher.rs
@@ -1,9 +1,9 @@
-use fltk::image::PngImage;
+use fltk::image::SharedImage;
 
 pub trait Searcher {
     fn handles(&self, pattern: &str) -> bool;
     // Tuple: (icon, text, data).
     //
-    fn search(&mut self, pattern: &str) -> Vec<(Option<PngImage>, String, Option<String>)>;
+    fn search(&mut self, pattern: &str) -> Vec<(Option<SharedImage>, String, Option<String>)>;
     fn execute(&self, entry: String);
 }


### PR DESCRIPTION
This has been possible due to the latest SharedImage::from_image [fix](https://github.com/fltk-rs/fltk-rs/commit/62c4b8c2a6ed777258da2303bf16bc67055070de).