### PR TITLE
Cleanups to PMSpotlight

### DIFF
--- a/src/gui/pm_spotlight_app.rs
+++ b/src/gui/pm_spotlight_app.rs
@@ -115,15 +115,15 @@ impl PMSpotlightApp {
         // It seems that Enter-initiated callback is not supported for browsers.
         //
         browser.handle(move |browser, _| {
-            if let Some(focused) = focus() {
-                if focused.is_same(browser) {
-                    // An alternative solution was to reset when tapping key up from the topmost Browser entry,
-                    // but this is not feasible with fltk(-rs), because:
-                    //
-                    // - the event is fired after the selection is changed
-                    // - the selection doesn't go above the first entry
-                    //
-                    if event_key_down(Key::Enter) {
+            // An alternative solution was to reset when tapping key up from the topmost Browser entry,
+            // but this is not feasible with fltk(-rs), because:
+            //
+            // - the event is fired after the selection is changed
+            // - the selection doesn't go above the first entry
+            //
+            if event_key_down(Key::Enter) {
+                if let Some(focused) = focus() {
+                    if focused.is_same(browser) {
                         let selected_line = if browser.value() > 0 {
                             browser.value()
                         } else if browser.size() >= 0 {


### PR DESCRIPTION
Notable: correction of the APIs used to invoke keypresses; the rest is minor.