### PR TITLE
EmojiSearcher: Exit after execution

### DIFF
--- a/src/search/emoji_searcher.rs
+++ b/src/search/emoji_searcher.rs
@@ -3,6 +3,7 @@ use fltk::{
     image::{PngImage, SharedImage},
 };
 use phf::phf_map;
+use std::process;
 
 use super::{search_result_entry::SearchResultEntry, searcher::Searcher};
 use crate::{
@@ -170,5 +171,6 @@ impl Searcher for EmojiSearcher {
 
     fn execute(&self, emoji: String) {
         copy_to_clipboard(emoji);
+        process::exit(0);
     }
 }


### PR DESCRIPTION
It looked like a good idea to keep it on, for contexts where emojis are used frequently, but the switch back procedure is one key combination far anyway (Alt-tab, before, in order to switch back to PMS).