### PR TITLE
Add wildcard support to skip paths (and other)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 dirs = "4.0.0"
 fltk = {git = "https://github.com/fltk-rs/fltk-rs", rev = "a0402da3d160f55a5d41b1a8daec3d7a41f58fbc"}
 phf = {version = "0.10.1", features = ["macros"]}
-# regex = "1.5.5"
+regex = "1.5.5"
 serde = {version = "1.0.136", features = ["derive"]}
 toml = "0.5.9"
 walkdir = "2.3.2"

--- a/src/search/file_searcher.rs
+++ b/src/search/file_searcher.rs
@@ -17,6 +17,8 @@ pub struct FileSearcher {
     search_paths: Vec<(String, usize)>,
     skip_paths: Vec<Regex>,
     stop_search: bool,
+    // It's noticeably slow to instantiate once for each file skip test.
+    re_is_hidden: Regex,
 }
 
 impl FileSearcher {
@@ -37,6 +39,7 @@ impl FileSearcher {
             search_paths,
             skip_paths,
             stop_search: false,
+            re_is_hidden: Regex::new(r"/\.[^/]+$").unwrap(),
         }
     }
 
@@ -103,9 +106,7 @@ impl FileSearcher {
             return true;
         };
 
-        let is_hidden_re = Regex::new(r"/\.[^/]+$").unwrap();
-
-        if is_hidden_re.is_match(&fullname) {
+        if self.re_is_hidden.is_match(&fullname) {
             return true;
         }
 

--- a/src/search/file_searcher.rs
+++ b/src/search/file_searcher.rs
@@ -11,6 +11,8 @@ use crate::{
     helpers::filenames::map_filenames_to_short_names,
 };
 
+const DISALLOWED_PATH_CHARS: &str = r"[^-\w*_./]";
+
 pub struct FileSearcher {
     search_paths: Vec<(String, usize)>,
     skip_paths: Vec<(String, bool)>,
@@ -141,8 +143,14 @@ impl FileSearcher {
 }
 
 impl Searcher for FileSearcher {
-    fn handles(&self, _pattern: &str) -> bool {
-        true
+    fn handles(&self, pattern: &str) -> bool {
+        let re = Regex::new(DISALLOWED_PATH_CHARS).unwrap();
+
+        if re.is_match(pattern) {
+            panic!("Only alphanum and *_-./ are allowed");
+        } else {
+            true
+        }
     }
 
     fn search(&mut self, pattern: String, sender: Sender<MessageEvent>, search_id: u32) {

--- a/src/search/file_searcher.rs
+++ b/src/search/file_searcher.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 const DISALLOWED_PATH_CHARS: &str = r"[^-\w*_./]";
+const MIN_CHARS: usize = 2;
 
 pub struct FileSearcher {
     search_paths: Vec<(String, usize)>,
@@ -46,9 +47,9 @@ impl FileSearcher {
     fn process_search_path_definition(mut path: &str) -> (String, usize) {
         let mut depth = 255;
 
-        let re = Regex::new(r"(.+)\{(\d)\}$").unwrap();
+        let re_path_with_depth = Regex::new(r"(.+)\{(\d)\}$").unwrap();
 
-        if let Some(captures) = re.captures(path) {
+        if let Some(captures) = re_path_with_depth.captures(path) {
             path = captures.get(1).unwrap().as_str();
             depth = captures.get(2).unwrap().as_str().parse().unwrap();
         }
@@ -135,9 +136,9 @@ impl FileSearcher {
 
 impl Searcher for FileSearcher {
     fn handles(&self, pattern: &str) -> bool {
-        let re = Regex::new(DISALLOWED_PATH_CHARS).unwrap();
+        let re_disallowed_chars = Regex::new(DISALLOWED_PATH_CHARS).unwrap();
 
-        if re.is_match(pattern) {
+        if re_disallowed_chars.is_match(pattern) {
             panic!("Only alphanum and *_-./ are allowed");
         } else {
             true
@@ -145,7 +146,7 @@ impl Searcher for FileSearcher {
     }
 
     fn search(&mut self, pattern: String, sender: Sender<MessageEvent>, search_id: u32) {
-        if pattern.chars().collect::<Vec<_>>().len() < 2 {
+        if pattern.chars().collect::<Vec<_>>().len() < MIN_CHARS {
             return;
         }
 


### PR DESCRIPTION
This was simpler with regexes, so the dependency has been restored.

Other notable changes, besides minor refactorings:

- user patterns are now limited to certain characters
- the skip paths definition format has been changed, in order to allow a unified logic for paths skipping