### PR TITLE
FileSearcher: Skip errors during search (log only)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ strip = true
 [dependencies]
 dirs = "4.0.0"
 fltk = "1.3.5"
-phf = {version = "0.10.1", features = ["macros"]}
+phf = { version = "0.10.1", features = ["macros"] }
 regex = "1.5.5"
-serde = {version = "1.0.136", features = ["derive"]}
+serde = { version = "1.0.136", features = ["derive"] }
 toml = "0.5.9"
 walkdir = "2.3.2"

--- a/src/search/file_searcher.rs
+++ b/src/search/file_searcher.rs
@@ -172,9 +172,13 @@ impl Searcher for FileSearcher {
             // We can't filter out+in in a single pass, because if we filter out a directory, WalkDir will
             // stop recursing.
             //
-            walker
-                .into_iter()
-                .filter_map(|e| Self::include_entry(&e.unwrap(), &re_pattern))
+            walker.into_iter().filter_map(|entry| match entry {
+                Ok(entry) => Self::include_entry(&entry, &re_pattern),
+                Err(error) => {
+                    eprintln!("{:?}", error);
+                    None
+                }
+            })
         };
 
         // Ignore nonexisting search paths; a legitimate use case is, for example, a shared config


### PR DESCRIPTION
It's undesirable to crash (e.g. subdirectory with restricted permissions); better log and ignore.